### PR TITLE
password reset functionality added

### DIFF
--- a/apps/http/.env.example
+++ b/apps/http/.env.example
@@ -12,7 +12,7 @@ RAZORPAY_WEBHOOK_SECRET="your_razorpay_webhook_secret"
 GOOGLE_CLIENT_ID="your_google_client_id"
 
 #Kafka things
-KAFKA_CLIENT_ID="your_kafka_client_id"
+KAFKA_CLIENT_ID="http-producer"
 KAFKA_BROKER="localhost:29092" # docker-network:port
 
 #JWT things

--- a/apps/http/src/routes/userRoutes.ts
+++ b/apps/http/src/routes/userRoutes.ts
@@ -7,6 +7,7 @@ import {
   requestOtp,
   registerPartner,
   submitOtp,
+  resetPassword,
   logout,
   updateFcmToken
   
@@ -20,6 +21,7 @@ userRoute.post("/login", login);
 userRoute.post("/google", googleLogin);
 userRoute.post("/otp", requestOtp);
 userRoute.post("/submitOtp", submitOtp);
+userRoute.post("/passwordReset", resetPassword);
 userRoute.get("/profile", isAuthenticatedUser, getProfile);
 userRoute.post('/updateFcmToken', isAuthenticatedUser, updateFcmToken);
 userRoute.get("/logout", isAuthenticatedUser,logout);

--- a/apps/http/src/schemas/userSchemas.ts
+++ b/apps/http/src/schemas/userSchemas.ts
@@ -13,14 +13,25 @@ export const loginSchema = z.object({
   password: z.string(),
 });
 
+enum RequestType {
+  verification = "verification",
+  reset = "passwordReset",
+}
 
 export const requestOtpSchema = z.object({
   number: z.string(),
+  reqType: z.nativeEnum(RequestType),
 });
 
 export const submitOtpSchema = z.object({
   number: z.string(),
   otp: z.string(),
+});
+
+export const resetPasswordSchema = z.object({
+  number: z.string(),
+  otp: z.string(),
+  newPassword: z.string().min(8),
 });
 
 export const smsMessage = z.object({

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -5,6 +5,10 @@ import prisma from "@repo/db/client";
 dotenv.config();
 
 const JWT_SECRET = process.env.JWT_SECRET || "your-secret-key";
+interface OtpRequestType {
+	otp: string;
+	reqType: "verification" | "passwordReset";
+}
 
 export function generateToken(userId: string): string {
 	return jwt.sign({ userId }, JWT_SECRET, { expiresIn: "365d" });
@@ -14,6 +18,14 @@ export function generateOTP(): string {
 	return Math.floor(1000 + Math.random() * 9000).toString();
 }
 
-export function createVerificationMessage(otp: string): string {
-	return `Cut the Q: Verify yourself with this OTP: ${otp}. Skip the wait, join the revolution!`;
+export function createVerificationMessage({otp,reqType}:OtpRequestType): string {
+	if(reqType === "verification"){
+		return `Cut the Q: Verify yourself with this OTP: ${otp}. Skip the wait, join the revolution!`;
+	}
+	else if(reqType === "passwordReset"){
+		return `Cut the Q: Reset your password with this OTP: ${otp}.`;
+	}
+	else{
+		return `Cut the Q: Message type unknown, OTP ${otp}.`;
+	}
 }


### PR DESCRIPTION
Update the frontend logic for OTP request to include the `reqType` variable alongside other fields.
- example:
 ```typescript
  axios.post(
   "http://localhost:3000/api/v1/otp",
   {
      number:"8302020978",
      reqType:"verification"
    });
  enum RequestType { 
      "verification",
      "passwordReset"
   }  


