### PR TITLE
 feat: add route for getting all transactions of user through pagination

### DIFF
--- a/apps/http/src/controllers/userController.ts
+++ b/apps/http/src/controllers/userController.ts
@@ -662,6 +662,28 @@ const deleteAccount = async (
 	}
 };
 
+const getTransaction = async ( req: CustomRequest, res: Response): Promise<any> => {
+   try {
+     const { id, page } = req.params;
+	 const transactions = await prisma.order.findMany({
+		 where: {
+			 userId: id,
+		 },
+		 take: 5,
+		 skip: 5 * (page - 1),
+		 orderBy: {
+			 createdAt: "desc",
+		 },
+	 });
+	 res.status(200).json(transactions);
+
+   } catch (error) {
+	 console.error(error);
+	 res.status(500).json({ message: SERVER_ERROR });
+   }
+
+}
+
 export {
 	changePassword,
 	deleteAccount,
@@ -678,4 +700,5 @@ export {
 	updateFcmToken,
 	updatePhoneNumber,
 	verifyOtp,
+	getTransaction,
 };

--- a/apps/http/src/controllers/userController.ts
+++ b/apps/http/src/controllers/userController.ts
@@ -34,6 +34,7 @@ import {
 import { CustomRequest } from "../types/userTypes";
 import { generateRandomStringWithRandomLength, hashString } from "../utils";
 import { parse } from "path";
+import orderRouter from "../routes/orderRoutes";
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || "";
 const SALT_ROUNDS = 10;
@@ -691,6 +692,22 @@ const getAllOrders = async (
       orderBy: {
         createdAt: "desc",
       },
+	  include:{
+		OrderItem:{
+			
+			include:{
+				menuItem:{
+					select:{
+						name:true,
+						id:true,
+						price:true,
+						itemImage:true
+					}
+				}
+			}
+		}
+
+	  }
 	 
     });
 	const isMore= transactions.length>5;

--- a/apps/http/src/controllers/userController.ts
+++ b/apps/http/src/controllers/userController.ts
@@ -32,6 +32,7 @@ import {
 } from "../schemas/userSchemas";
 import { CustomRequest } from "../types/userTypes";
 import { generateRandomStringWithRandomLength, hashString } from "../utils";
+import { parse } from "path";
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || "";
 const SALT_ROUNDS = 10;
@@ -665,6 +666,10 @@ const deleteAccount = async (
 const getTransaction = async ( req: CustomRequest, res: Response): Promise<any> => {
    try {
      const { id, page } = req.params;
+	 const pageNum = parseInt(page);
+	 if (isNaN(pageNum) || pageNum < 1) {
+		 return res.status(400).json({ message: "Invalid page number" });
+	 }
 	 const transactions = await prisma.order.findMany({
 		 where: {
 			 userId: id,

--- a/apps/http/src/controllers/userController.ts
+++ b/apps/http/src/controllers/userController.ts
@@ -1,18 +1,18 @@
 import {
-	INVALID_CREDENTIALS,
-	INVALID_GOOGLE_TOKEN,
-	INVALID_INPUT,
-	INVALID_OTP,
-	OTP_SENT,
-	SERVER_ERROR,
-	USER_ALREADY_EXISTS,
-	USER_NOT_REGISTERED,
+  INVALID_CREDENTIALS,
+  INVALID_GOOGLE_TOKEN,
+  INVALID_INPUT,
+  INVALID_OTP,
+  OTP_SENT,
+  SERVER_ERROR,
+  USER_ALREADY_EXISTS,
+  USER_NOT_REGISTERED,
 } from "@repo/constants";
 import prisma from "@repo/db/client";
 import {
-	createVerificationMessage,
-	generateOTP,
-	generateToken,
+  createVerificationMessage,
+  generateOTP,
+  generateToken,
 } from "@repo/utils";
 import bcrypt from "bcrypt";
 import "dotenv/config";
@@ -21,14 +21,15 @@ import { OAuth2Client } from "google-auth-library";
 import z from "zod";
 import { KafkaPublisher } from "../publisher/kafka";
 import {
-	changePasswordSchema,
-	deleteAccountSchema,
-	forgotPasswordSchema,
-	loginSchema,
-	registerSchema,
-	requestOtpSchema,
-	submitOtpSchema,
-	verifyOtpAndResetPasswordSchema,
+  changePasswordSchema,
+  deleteAccountSchema,
+  forgotPasswordSchema,
+  loginSchema,
+  registerSchema,
+  requestOtpSchema,
+  submitOtpSchema,
+  verifyOtpAndResetPasswordSchema,
+  getAllOrdersSchema
 } from "../schemas/userSchemas";
 import { CustomRequest } from "../types/userTypes";
 import { generateRandomStringWithRandomLength, hashString } from "../utils";
@@ -39,671 +40,683 @@ const SALT_ROUNDS = 10;
 const googleClient = new OAuth2Client(GOOGLE_CLIENT_ID);
 
 const register = async (
-	req: Request,
-	res: Response,
-	next: NextFunction
+  req: Request,
+  res: Response,
+  next: NextFunction
 ): Promise<any> => {
-	try {
-		const { firstName, lastName, email, phoneNo, password } =
-			registerSchema.parse(req.body);
+  try {
+    const { firstName, lastName, email, phoneNo, password } =
+      registerSchema.parse(req.body);
 
-		const existingUser = await prisma.user.findFirst({
-			where: {
-				OR: [{ email: email }, { phoneNumber: phoneNo }],
-			},
-		});
-		if (existingUser) {
-			return res.status(400).json({ message: USER_ALREADY_EXISTS });
-		}
+    const existingUser = await prisma.user.findFirst({
+      where: {
+        OR: [{ email: email }, { phoneNumber: phoneNo }],
+      },
+    });
+    if (existingUser) {
+      return res.status(400).json({ message: USER_ALREADY_EXISTS });
+    }
 
-		const hashedPassword = await bcrypt.hash(password, SALT_ROUNDS);
+    const hashedPassword = await bcrypt.hash(password, SALT_ROUNDS);
 
-		const newUser = await prisma.user.create({
-			data: {
-				firstName,
-				lastName,
-				email,
-				phoneNumber: phoneNo,
-				password: hashedPassword,
-			},
-			select: {
-				id: true,
-				firstName: true,
-				lastName: true,
-				userProfile: true,
-				email: true,
-				phoneNumber: true,
-				isVerified: true,
-				role: true,
-			},
-		});
+    const newUser = await prisma.user.create({
+      data: {
+        firstName,
+        lastName,
+        email,
+        phoneNumber: phoneNo,
+        password: hashedPassword,
+      },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        userProfile: true,
+        email: true,
+        phoneNumber: true,
+        isVerified: true,
+        role: true,
+      },
+    });
 
-		const token = generateToken(newUser.id);
-		res.status(201).json({ user: newUser, token });
-	} catch (error) {
-		if (error instanceof z.ZodError) {
-			res.status(400).json({ message: INVALID_INPUT, errors: error.errors });
-		} else {
-			res.status(500).json({ message: SERVER_ERROR });
-		}
-	}
+    const token = generateToken(newUser.id);
+    res.status(201).json({ user: newUser, token });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ message: INVALID_INPUT, errors: error.errors });
+    } else {
+      res.status(500).json({ message: SERVER_ERROR });
+    }
+  }
 };
 
 const login = async (req: Request, res: Response): Promise<any> => {
-	try {
-		const { email, password } = loginSchema.parse(req.body);
+  try {
+    const { email, password } = loginSchema.parse(req.body);
 
-		const user = await prisma.user.findFirst({
-			where: {
-				OR: [{ email: email }, { phoneNumber: email }],
-			},
-			select: {
-				id: true,
-				firstName: true,
-				lastName: true,
-				userProfile: true,
-				email: true,
-				phoneNumber: true,
-				canteenId: true,
-				isVerified: true,
-				role: true,
-				password: true,
-			},
-		});
-		if (!user || user.password == null) {
-			return res.status(400).json({ message: INVALID_CREDENTIALS });
-		}
+    const user = await prisma.user.findFirst({
+      where: {
+        OR: [{ email: email }, { phoneNumber: email }],
+      },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        userProfile: true,
+        email: true,
+        phoneNumber: true,
+        canteenId: true,
+        isVerified: true,
+        role: true,
+        password: true,
+      },
+    });
+    if (!user || user.password == null) {
+      return res.status(400).json({ message: INVALID_CREDENTIALS });
+    }
 
-		const isPasswordValid = await bcrypt.compare(password, user.password);
-		if (!isPasswordValid) {
-			return res.status(400).json({ message: INVALID_CREDENTIALS });
-		}
+    const isPasswordValid = await bcrypt.compare(password, user.password);
+    if (!isPasswordValid) {
+      return res.status(400).json({ message: INVALID_CREDENTIALS });
+    }
 
-		const token = generateToken(user.id);
-		user.password = null;
-		res.status(200).json({ user, token });
-	} catch (error) {
-		if (error instanceof z.ZodError) {
-			res.status(400).json({ message: INVALID_INPUT, errors: error.errors });
-		} else {
-			res.status(500).json({ message: SERVER_ERROR });
-		}
-	}
+    const token = generateToken(user.id);
+    user.password = null;
+    res.status(200).json({ user, token });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ message: INVALID_INPUT, errors: error.errors });
+    } else {
+      res.status(500).json({ message: SERVER_ERROR });
+    }
+  }
 };
 const googleLogin = async (req: Request, res: Response): Promise<any> => {
-	try {
-		const { token } = req.body;
-		const ticket = await googleClient.verifyIdToken({
-			idToken: token,
-			audience: GOOGLE_CLIENT_ID,
-		});
+  try {
+    const { token } = req.body;
+    const ticket = await googleClient.verifyIdToken({
+      idToken: token,
+      audience: GOOGLE_CLIENT_ID,
+    });
 
-		const payload = ticket.getPayload();
-		if (!payload || !payload.email) {
-			return res.status(400).json({ message: INVALID_GOOGLE_TOKEN });
-		}
+    const payload = ticket.getPayload();
+    if (!payload || !payload.email) {
+      return res.status(400).json({ message: INVALID_GOOGLE_TOKEN });
+    }
 
-		let user = await prisma.user.findFirst({
-			where: { email: payload.email },
-			select: {
-				id: true,
-				firstName: true,
-				lastName: true,
-				userProfile: true,
-				email: true,
-				phoneNumber: true,
-				isVerified: true,
-				role: true,
-			},
-		});
-		if (!user) {
-			return res.status(400).json({ message: USER_NOT_REGISTERED });
-		}
+    let user = await prisma.user.findFirst({
+      where: { email: payload.email },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        userProfile: true,
+        email: true,
+        phoneNumber: true,
+        isVerified: true,
+        role: true,
+      },
+    });
+    if (!user) {
+      return res.status(400).json({ message: USER_NOT_REGISTERED });
+    }
 
-		await prisma.user.update({
-			data: { googleId: token },
-			where: { email: payload.email },
-		});
+    await prisma.user.update({
+      data: { googleId: token },
+      where: { email: payload.email },
+    });
 
-		const jwtToken = generateToken(user.id);
-		res.json({ token: jwtToken });
-	} catch (error) {
-		res.status(500).json({ message: SERVER_ERROR });
-	}
+    const jwtToken = generateToken(user.id);
+    res.json({ token: jwtToken });
+  } catch (error) {
+    res.status(500).json({ message: SERVER_ERROR });
+  }
 };
 
 const requestOtp = async (req: Request, res: Response): Promise<void> => {
-	try {
-		const { number } = requestOtpSchema.parse(req.body);
-		const user = await prisma.user.findUnique({
-			where: {
-				phoneNumber: number,
-			},
-			select: {
-				email: true,
-			},
-		});
+  try {
+    const { number } = requestOtpSchema.parse(req.body);
+    const user = await prisma.user.findUnique({
+      where: {
+        phoneNumber: number,
+      },
+      select: {
+        email: true,
+      },
+    });
 
-		if (!user) {
-			res.status(400).json({ message: USER_NOT_REGISTERED });
-			return;
-		}
+    if (!user) {
+      res.status(400).json({ message: USER_NOT_REGISTERED });
+      return;
+    }
 
-		const otp = generateOTP();
-		await prisma.user.update({
-			where: {
-				phoneNumber: number,
-			},
-			data: {
-				otp: otp,
-			},
-		});
-		const message = createVerificationMessage(otp);
-		const kafkaPublisher = KafkaPublisher.getInstance();
-		await kafkaPublisher.publishToKafka("sms", {
-			to: "+91" + number,
-			content: `${otp}`,
-		});
-		res.status(200).json({ message: OTP_SENT });
-	} catch (error) {
-		if (error instanceof z.ZodError) {
-			res.status(400).json({ message: "Invalid input", errors: error.errors });
-		} else {
-			console.error("Error in requestOtp:", error);
-			res.status(500).json({ message: SERVER_ERROR });
-		}
-	}
+    const otp = generateOTP();
+    await prisma.user.update({
+      where: {
+        phoneNumber: number,
+      },
+      data: {
+        otp: otp,
+      },
+    });
+    const message = createVerificationMessage(otp);
+    const kafkaPublisher = KafkaPublisher.getInstance();
+    await kafkaPublisher.publishToKafka("sms", {
+      to: "+91" + number,
+      content: `${otp}`,
+    });
+    res.status(200).json({ message: OTP_SENT });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ message: "Invalid input", errors: error.errors });
+    } else {
+      console.error("Error in requestOtp:", error);
+      res.status(500).json({ message: SERVER_ERROR });
+    }
+  }
 };
 
 const submitOtp = async (req: Request, res: Response): Promise<any> => {
-	try {
-		const { number, otp } = submitOtpSchema.parse(req.body);
-		const user = await prisma.user.findUnique({
-			where: {
-				phoneNumber: number,
-			},
-			select: {
-				id: true,
-				firstName: true,
-				lastName: true,
-				userProfile: true,
-				email: true,
-				phoneNumber: true,
-				isVerified: true,
-				role: true,
-				otp: true,
-			},
-		});
-		if (!user) {
-			return res.status(400).json({ message: USER_NOT_REGISTERED });
-		}
-		if (user.otp !== otp) {
-			return res.status(401).json({ message: INVALID_OTP });
-		}
-		const updatedUser = await prisma.user.update({
-			where: {
-				phoneNumber: number,
-			},
-			data: {
-				isVerified: true,
-			},
-			select: {
-				id: true,
-				firstName: true,
-				lastName: true,
-				userProfile: true,
-				email: true,
-				phoneNumber: true,
-				isVerified: true,
-				role: true,
-			},
-		});
-		res.status(200).json(updatedUser);
-	} catch (error) {
-		res.status(500).json({ message: SERVER_ERROR });
-	}
+  try {
+    const { number, otp } = submitOtpSchema.parse(req.body);
+    const user = await prisma.user.findUnique({
+      where: {
+        phoneNumber: number,
+      },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        userProfile: true,
+        email: true,
+        phoneNumber: true,
+        isVerified: true,
+        role: true,
+        otp: true,
+      },
+    });
+    if (!user) {
+      return res.status(400).json({ message: USER_NOT_REGISTERED });
+    }
+    if (user.otp !== otp) {
+      return res.status(401).json({ message: INVALID_OTP });
+    }
+    const updatedUser = await prisma.user.update({
+      where: {
+        phoneNumber: number,
+      },
+      data: {
+        isVerified: true,
+      },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        userProfile: true,
+        email: true,
+        phoneNumber: true,
+        isVerified: true,
+        role: true,
+      },
+    });
+    res.status(200).json(updatedUser);
+  } catch (error) {
+    res.status(500).json({ message: SERVER_ERROR });
+  }
 };
 
 const getProfile = async (req: CustomRequest, res: Response): Promise<any> => {
-	try {
-		const user = await prisma.user.findUnique({
-			where: {
-				id: req.user?.id,
-			},
-			select: {
-				id: true,
-				firstName: true,
-				lastName: true,
-				userProfile: true,
-				canteenId: true,
-				email: true,
-				phoneNumber: true,
-				isVerified: true,
-				counter: true,
-				role: true,
-			},
-		});
-		if (!user) {
-			return res.status(400).json({ message: USER_NOT_REGISTERED });
-		}
-		if (user.role === "PARTNER" && !user.counter) {
-			const updatedUser = await prisma.user.update({
-				where: {
-					id: user.id,
-				},
-				data: {
-					counter: 1,
-				},
-			});
-			user.counter = updatedUser.counter;
-		}
-		res.json(user);
-	} catch (error) {
-		res.status(500).json({ message: SERVER_ERROR });
-	}
+  try {
+    const user = await prisma.user.findUnique({
+      where: {
+        id: req.user?.id,
+      },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        userProfile: true,
+        canteenId: true,
+        email: true,
+        phoneNumber: true,
+        isVerified: true,
+        counter: true,
+        role: true,
+      },
+    });
+    if (!user) {
+      return res.status(400).json({ message: USER_NOT_REGISTERED });
+    }
+    if (user.role === "PARTNER" && !user.counter) {
+      const updatedUser = await prisma.user.update({
+        where: {
+          id: user.id,
+        },
+        data: {
+          counter: 1,
+        },
+      });
+      user.counter = updatedUser.counter;
+    }
+    res.json(user);
+  } catch (error) {
+    res.status(500).json({ message: SERVER_ERROR });
+  }
 };
 
 const registerPartner = async (
-	req: CustomRequest,
-	res: Response,
-	next: NextFunction
+  req: CustomRequest,
+  res: Response,
+  next: NextFunction
 ): Promise<any> => {
-	try {
-		const { canteenId, canteenPassword } = req.body;
-		if (!canteenId || !canteenPassword) {
-			return res.status(400).json({ message: INVALID_CREDENTIALS });
-		}
-		const canteen = await prisma.canteen.findUnique({
-			where: {
-				id: canteenId,
-			},
-		});
+  try {
+    const { canteenId, canteenPassword } = req.body;
+    if (!canteenId || !canteenPassword) {
+      return res.status(400).json({ message: INVALID_CREDENTIALS });
+    }
+    const canteen = await prisma.canteen.findUnique({
+      where: {
+        id: canteenId,
+      },
+    });
 
-		if (!canteen) {
-			return res.status(400).json({ message: INVALID_CREDENTIALS });
-		}
-		const isPasswordValid = await bcrypt.compare(
-			canteenPassword,
-			canteen.password
-		);
-		if (!isPasswordValid) {
-			return res.status(400).json({ message: INVALID_CREDENTIALS });
-		}
-		const user = await prisma.user.update({
-			where: {
-				id: req.user!.id,
-			},
-			data: {
-				canteenId: canteen.id,
-				role: "PARTNER",
-			},
-		});
-		res.json(user);
-	} catch (e) {
-		res.status(500).json({ message: SERVER_ERROR });
-	}
+    if (!canteen) {
+      return res.status(400).json({ message: INVALID_CREDENTIALS });
+    }
+    const isPasswordValid = await bcrypt.compare(
+      canteenPassword,
+      canteen.password
+    );
+    if (!isPasswordValid) {
+      return res.status(400).json({ message: INVALID_CREDENTIALS });
+    }
+    const user = await prisma.user.update({
+      where: {
+        id: req.user!.id,
+      },
+      data: {
+        canteenId: canteen.id,
+        role: "PARTNER",
+      },
+    });
+    res.json(user);
+  } catch (e) {
+    res.status(500).json({ message: SERVER_ERROR });
+  }
 };
 
 const logout = async (req: CustomRequest, res: Response): Promise<any> => {
-	try {
-		res.status(200).json({ message: "Logout successful" });
-	} catch (error) {
-		res.status(500).json({ message: SERVER_ERROR });
-	}
+  try {
+    res.status(200).json({ message: "Logout successful" });
+  } catch (error) {
+    res.status(500).json({ message: SERVER_ERROR });
+  }
 };
 const updateFcmToken = async (req: CustomRequest, res: Response) => {
-	const { fcmToken } = req.body;
-	const userId = req.user!.id;
-	await prisma.user.update({
-		where: { id: userId },
-		data: { fcmToken },
-	});
-	res.json({ success: true });
+  const { fcmToken } = req.body;
+  const userId = req.user!.id;
+  await prisma.user.update({
+    where: { id: userId },
+    data: { fcmToken },
+  });
+  res.json({ success: true });
 };
 
 async function forgetPassword(req: Request, res: Response): Promise<any> {
-	try {
-		const { phoneNo } = forgotPasswordSchema.parse(req.body);
+  try {
+    const { phoneNo } = forgotPasswordSchema.parse(req.body);
 
-		const user = await prisma.user.findUnique({
-			where: { phoneNumber: phoneNo },
-			select: { id: true, phoneNumber: true, email: true },
-		});
+    const user = await prisma.user.findUnique({
+      where: { phoneNumber: phoneNo },
+      select: { id: true, phoneNumber: true, email: true },
+    });
 
-		if (!user) {
-			return res.status(400).json({ message: USER_NOT_REGISTERED });
-		}
+    if (!user) {
+      return res.status(400).json({ message: USER_NOT_REGISTERED });
+    }
 
-		const otp = generateOTP();
-		const otpExpiry = new Date(Date.now() + 15 * 60 * 1000); // 15 minutes
+    const otp = generateOTP();
+    const otpExpiry = new Date(Date.now() + 15 * 60 * 1000); // 15 minutes
 
-		await prisma.user.update({
-			where: { id: user.id },
-			data: {
-				otp: otp,
-				expire: otpExpiry,
-			},
-		});
+    await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        otp: otp,
+        expire: otpExpiry,
+      },
+    });
 
-		const kafkaPublisher = KafkaPublisher.getInstance();
-		await kafkaPublisher.publishToKafka("sms", {
-			to: "+91" + user.phoneNumber,
-			content: `${otp}`,
-		});
+    const kafkaPublisher = KafkaPublisher.getInstance();
+    await kafkaPublisher.publishToKafka("sms", {
+      to: "+91" + user.phoneNumber,
+      content: `${otp}`,
+    });
 
-		return res.json({
-			success: true,
-			message: OTP_SENT,
-		});
-	} catch (error) {
-		if (error instanceof z.ZodError) {
-			return res
-				.status(400)
-				.json({ message: INVALID_INPUT, errors: error.errors });
-		}
-		return res.status(500).json({ message: SERVER_ERROR });
-	}
+    return res.json({
+      success: true,
+      message: OTP_SENT,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res
+        .status(400)
+        .json({ message: INVALID_INPUT, errors: error.errors });
+    }
+    return res.status(500).json({ message: SERVER_ERROR });
+  }
 }
 
 async function resetPassword(req: Request, res: Response): Promise<any> {
-	try {
-		const { phoneNo, password, confirmPassword } =
-			verifyOtpAndResetPasswordSchema.parse(req.body);
-		const token = req.params.token;
-		if (password !== confirmPassword || !token) {
-			return res.status(400).json({ message: "Passwords don't match" });
-		}
-		const hashedToken = await hashString(token);
+  try {
+    const { phoneNo, password, confirmPassword } =
+      verifyOtpAndResetPasswordSchema.parse(req.body);
+    const token = req.params.token;
+    if (password !== confirmPassword || !token) {
+      return res.status(400).json({ message: "Passwords don't match" });
+    }
+    const hashedToken = await hashString(token);
 
-		const user = await prisma.user.findFirst({
-			where: {
-				phoneNumber: phoneNo,
-				resetPasswordToken: hashedToken,
-				expire: { gt: new Date() },
-			},
-			select: {
-				id: true,
-				email: true,
-				phoneNumber: true,
-				isVerified: true,
-			},
-		});
+    const user = await prisma.user.findFirst({
+      where: {
+        phoneNumber: phoneNo,
+        resetPasswordToken: hashedToken,
+        expire: { gt: new Date() },
+      },
+      select: {
+        id: true,
+        email: true,
+        phoneNumber: true,
+        isVerified: true,
+      },
+    });
 
-		if (!user) {
-			return res.status(400).json({ message: INVALID_OTP });
-		}
+    if (!user) {
+      return res.status(400).json({ message: INVALID_OTP });
+    }
 
-		const hashedPassword = await bcrypt.hash(password, SALT_ROUNDS);
-		const updatedUser = await prisma.user.update({
-			where: { id: user.id },
-			data: {
-				password: hashedPassword,
-				resetPasswordToken: null,
-				expire: null,
-			},
-			select: {
-				id: true,
-				firstName: true,
-				lastName: true,
-				userProfile: true,
-				email: true,
-				phoneNumber: true,
-				isVerified: true,
-				role: true,
-			},
-		});
+    const hashedPassword = await bcrypt.hash(password, SALT_ROUNDS);
+    const updatedUser = await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        password: hashedPassword,
+        resetPasswordToken: null,
+        expire: null,
+      },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        userProfile: true,
+        email: true,
+        phoneNumber: true,
+        isVerified: true,
+        role: true,
+      },
+    });
 
-		const authToken = generateToken(user.id); // renamed from token to authToken
-		return res.json({
-			token: authToken,
-			user: updatedUser,
-		});
-	} catch (error) {
-		if (error instanceof z.ZodError) {
-			return res
-				.status(400)
-				.json({ message: INVALID_INPUT, errors: error.errors });
-		}
-		return res.status(500).json({ message: SERVER_ERROR });
-	}
+    const authToken = generateToken(user.id); // renamed from token to authToken
+    return res.json({
+      token: authToken,
+      user: updatedUser,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res
+        .status(400)
+        .json({ message: INVALID_INPUT, errors: error.errors });
+    }
+    return res.status(500).json({ message: SERVER_ERROR });
+  }
 }
 
 const verifyOtp = async (req: Request, res: Response): Promise<any> => {
-	try {
-		const { phoneNo, otp } = req.body;
-		if (!phoneNo || !otp) {
-			res.status(400).json({ success: false });
-			return;
-		}
-		const user = await prisma.user.findUnique({
-			where: {
-				phoneNumber: phoneNo,
-				otp: otp,
-			},
-		});
-		if (!user) {
-			return res.status(401).json({ message: INVALID_OTP });
-		}
-		const token = generateRandomStringWithRandomLength();
-		const hashedToken = await hashString(token);
-		await prisma.user.update({
-			where: {
-				phoneNumber: phoneNo,
-			},
-			data: {
-				resetPasswordToken: hashedToken,
-			},
-		});
-		res.json({ token });
-	} catch (error) {
-		return res.status(500).json({ message: SERVER_ERROR });
-	}
+  try {
+    const { phoneNo, otp } = req.body;
+    if (!phoneNo || !otp) {
+      res.status(400).json({ success: false });
+      return;
+    }
+    const user = await prisma.user.findUnique({
+      where: {
+        phoneNumber: phoneNo,
+        otp: otp,
+      },
+    });
+    if (!user) {
+      return res.status(401).json({ message: INVALID_OTP });
+    }
+    const token = generateRandomStringWithRandomLength();
+    const hashedToken = await hashString(token);
+    await prisma.user.update({
+      where: {
+        phoneNumber: phoneNo,
+      },
+      data: {
+        resetPasswordToken: hashedToken,
+      },
+    });
+    res.json({ token });
+  } catch (error) {
+    return res.status(500).json({ message: SERVER_ERROR });
+  }
 };
 async function changePassword(req: CustomRequest, res: Response): Promise<any> {
-	try {
-		const { oldPassword, newPassword } = changePasswordSchema.parse(req.body);
+  try {
+    const { oldPassword, newPassword } = changePasswordSchema.parse(req.body);
 
-		const user = await prisma.user.findUnique({
-			where: { id: req.user!.id },
-			select: {
-				id: true,
-				password: true,
-			},
-		});
+    const user = await prisma.user.findUnique({
+      where: { id: req.user!.id },
+      select: {
+        id: true,
+        password: true,
+      },
+    });
 
-		if (!user || !user.password) {
-			return res.status(400).json({ message: INVALID_CREDENTIALS });
-		}
+    if (!user || !user.password) {
+      return res.status(400).json({ message: INVALID_CREDENTIALS });
+    }
 
-		const isPasswordValid = await bcrypt.compare(oldPassword, user.password);
-		if (!isPasswordValid) {
-			return res.status(400).json({ message: INVALID_CREDENTIALS });
-		}
+    const isPasswordValid = await bcrypt.compare(oldPassword, user.password);
+    if (!isPasswordValid) {
+      return res.status(400).json({ message: INVALID_CREDENTIALS });
+    }
 
-		const hashedPassword = await bcrypt.hash(newPassword, SALT_ROUNDS);
-		await prisma.user.update({
-			where: { id: user.id },
-			data: {
-				password: hashedPassword,
-			},
-		});
+    const hashedPassword = await bcrypt.hash(newPassword, SALT_ROUNDS);
+    await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        password: hashedPassword,
+      },
+    });
 
-		return res.json({
-			success: true,
-			message: "Password changed successfully",
-		});
-	} catch (error) {
-		if (error instanceof z.ZodError) {
-			return res
-				.status(400)
-				.json({ message: INVALID_INPUT, errors: error.errors });
-		}
-		return res.status(500).json({ message: SERVER_ERROR });
-	}
+    return res.json({
+      success: true,
+      message: "Password changed successfully",
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res
+        .status(400)
+        .json({ message: INVALID_INPUT, errors: error.errors });
+    }
+    return res.status(500).json({ message: SERVER_ERROR });
+  }
 }
 
 const updatePhoneNumber = async (
-	req: CustomRequest,
-	res: Response
+  req: CustomRequest,
+  res: Response
 ): Promise<any> => {
-	try {
-		const { phoneNumber } = req.body;
+  try {
+    const { phoneNumber } = req.body;
 
-		// Validate phone number format
-		const phoneNumberRegex = /^[0-9]{10}$/;
-		if (!phoneNumber || !phoneNumberRegex.test(phoneNumber)) {
-			return res.status(400).json({
-				message: INVALID_INPUT,
-				details: "Phone number must be 10 digits",
-			});
-		}
+    // Validate phone number format
+    const phoneNumberRegex = /^[0-9]{10}$/;
+    if (!phoneNumber || !phoneNumberRegex.test(phoneNumber)) {
+      return res.status(400).json({
+        message: INVALID_INPUT,
+        details: "Phone number must be 10 digits",
+      });
+    }
 
-		// Ensure user exists and get their current data
-		const userId = req.user?.id;
-		if (!userId) {
-			return res.status(401).json({ message: "Unauthorized" });
-		}
+    // Ensure user exists and get their current data
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ message: "Unauthorized" });
+    }
 
-		const currentUser = await prisma.user.findUnique({
-			where: { id: userId },
-		});
-		if (!currentUser) {
-			return res.status(404).json({ message: USER_NOT_REGISTERED });
-		}
+    const currentUser = await prisma.user.findUnique({
+      where: { id: userId },
+    });
+    if (!currentUser) {
+      return res.status(404).json({ message: USER_NOT_REGISTERED });
+    }
 
-		// Check if phone number is already in use
-		const existingUser = await prisma.user.findUnique({
-			where: { phoneNumber },
-		});
-		if (existingUser && existingUser.id !== userId) {
-			return res.status(400).json({ message: USER_ALREADY_EXISTS });
-		}
+    // Check if phone number is already in use
+    const existingUser = await prisma.user.findUnique({
+      where: { phoneNumber },
+    });
+    if (existingUser && existingUser.id !== userId) {
+      return res.status(400).json({ message: USER_ALREADY_EXISTS });
+    }
 
-		const otp = generateOTP();
+    const otp = generateOTP();
 
-		// Update user with new phone number and OTP
-		await prisma.user.update({
-			where: { id: userId },
-			data: {
-				phoneNumber,
-				otp,
-				isVerified: false, // Reset verification status for new number
-			},
-		});
+    // Update user with new phone number and OTP
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        phoneNumber,
+        otp,
+        isVerified: false, // Reset verification status for new number
+      },
+    });
 
-		// Send OTP via Kafka
-		try {
-			const kafkaPublisher = KafkaPublisher.getInstance();
-			await kafkaPublisher.publishToKafka("sms", {
-				to: "+91" + phoneNumber,
-				content: `${otp}`,
-			});
-		} catch (kafkaError) {
-			console.error("Kafka publishing error:", kafkaError);
-			// Rollback the phone number update
-			await prisma.user.update({
-				where: { id: userId },
-				data: {
-					phoneNumber: currentUser.phoneNumber,
-					otp: null,
-					isVerified: currentUser.isVerified,
-				},
-			});
-			throw new Error("Failed to send OTP");
-		}
+    // Send OTP via Kafka
+    try {
+      const kafkaPublisher = KafkaPublisher.getInstance();
+      await kafkaPublisher.publishToKafka("sms", {
+        to: "+91" + phoneNumber,
+        content: `${otp}`,
+      });
+    } catch (kafkaError) {
+      console.error("Kafka publishing error:", kafkaError);
+      // Rollback the phone number update
+      await prisma.user.update({
+        where: { id: userId },
+        data: {
+          phoneNumber: currentUser.phoneNumber,
+          otp: null,
+          isVerified: currentUser.isVerified,
+        },
+      });
+      throw new Error("Failed to send OTP");
+    }
 
-		return res.status(200).json({ message: OTP_SENT });
-	} catch (error) {
-		console.error("Update phone number error:", error);
-		return res.status(500).json({
-			message: SERVER_ERROR,
-			details:
-				error instanceof Error ? error.message : "Unknown error occurred",
-		});
-	}
+    return res.status(200).json({ message: OTP_SENT });
+  } catch (error) {
+    console.error("Update phone number error:", error);
+    return res.status(500).json({
+      message: SERVER_ERROR,
+      details:
+        error instanceof Error ? error.message : "Unknown error occurred",
+    });
+  }
 };
 
 const deleteAccount = async (
-	req: CustomRequest,
-	res: Response
+  req: CustomRequest,
+  res: Response
 ): Promise<any> => {
-	try {
-		const { password } = deleteAccountSchema.parse(req.body);
+  try {
+    const { password } = deleteAccountSchema.parse(req.body);
 
-		const user = await prisma.user.findUnique({
-			where: { id: req.user!.id },
-			select: { id: true, password: true },
-		});
+    const user = await prisma.user.findUnique({
+      where: { id: req.user!.id },
+      select: { id: true, password: true },
+    });
 
-		if (!user) {
-			return res.status(400).json({ message: USER_NOT_REGISTERED });
-		}
+    if (!user) {
+      return res.status(400).json({ message: USER_NOT_REGISTERED });
+    }
 
-		if (!user.password) {
-			return res.status(400).json({ message: INVALID_CREDENTIALS });
-		}
+    if (!user.password) {
+      return res.status(400).json({ message: INVALID_CREDENTIALS });
+    }
 
-		const isPasswordValid = await bcrypt.compare(password, user.password);
-		if (!isPasswordValid) {
-			return res.status(400).json({ message: INVALID_CREDENTIALS });
-		}
+    const isPasswordValid = await bcrypt.compare(password, user.password);
+    if (!isPasswordValid) {
+      return res.status(400).json({ message: INVALID_CREDENTIALS });
+    }
 
-		await prisma.user.delete({
-			where: { id: req.user!.id },
-		});
+    await prisma.user.delete({
+      where: { id: req.user!.id },
+    });
 
-		return res.status(200).json({ message: "Account deleted successfully" });
-	} catch (error) {
-		if (error instanceof z.ZodError) {
-			return res
-				.status(400)
-				.json({ message: INVALID_INPUT, errors: error.errors });
-		}
-		return res.status(500).json({ message: SERVER_ERROR });
-	}
+    return res.status(200).json({ message: "Account deleted successfully" });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res
+        .status(400)
+        .json({ message: INVALID_INPUT, errors: error.errors });
+    }
+    return res.status(500).json({ message: SERVER_ERROR });
+  }
 };
 
-const getTransaction = async ( req: CustomRequest, res: Response): Promise<any> => {
-   try {
-     const { id, page } = req.params;
-	 const pageNum = parseInt(page);
-	 if (isNaN(pageNum) || pageNum < 1) {
-		 return res.status(400).json({ message: "Invalid page number" });
-	 }
-	 const transactions = await prisma.order.findMany({
-		 where: {
-			 userId: id,
-		 },
-		 take: 5,
-		 skip: 5 * (page - 1),
-		 orderBy: {
-			 createdAt: "desc",
-		 },
-	 });
-	 res.status(200).json(transactions);
+const getAllOrders = async (
+  req: CustomRequest,
+  res: Response
+): Promise<any> => {
+  try {
+    const { page } = getAllOrdersSchema.parse(req.params);
+	if(!page){
+		return res.status(400).json({ message: "Invalid page number" });
+	}
+    const pageNum = parseInt(page , 10);
+    const id = req.user?.canteenId;
+    if (!id) {
+      return res.status(400).json({ message: "Invalid user id" });
+    }
 
-   } catch (error) {
-	 console.error(error);
-	 res.status(500).json({ message: SERVER_ERROR });
-   }
-
-}
+    if (isNaN(pageNum) || pageNum < 1) {
+      return res.status(400).json({ message: "Invalid page number" });
+    }
+    const transactions = await prisma.order.findMany({
+      where: {
+        userId: id,
+      },
+      take: 5+5,
+      skip: 5 * (pageNum - 1),
+      orderBy: {
+        createdAt: "desc",
+      },
+	 
+    });
+	const isMore= transactions.length>5;
+	const paginatedOrders=transactions.slice(0,5);
+	res.status(200).json({transactions:paginatedOrders,hasNext:isMore});
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: SERVER_ERROR });
+  }
+};
 
 export {
-	changePassword,
-	deleteAccount,
-	forgetPassword,
-	getProfile,
-	googleLogin,
-	login,
-	logout,
-	register,
-	registerPartner,
-	requestOtp,
-	resetPassword,
-	submitOtp,
-	updateFcmToken,
-	updatePhoneNumber,
-	verifyOtp,
-	getTransaction,
+  changePassword,
+  deleteAccount,
+  forgetPassword,
+  getProfile,
+  googleLogin,
+  login,
+  logout,
+  register,
+  registerPartner,
+  requestOtp,
+  resetPassword,
+  submitOtp,
+  updateFcmToken,
+  updatePhoneNumber,
+  verifyOtp,
+  getAllOrders ,
 };

--- a/apps/http/src/controllers/userController.ts
+++ b/apps/http/src/controllers/userController.ts
@@ -695,7 +695,12 @@ const getAllOrders = async (
     });
 	const isMore= transactions.length>5;
 	const paginatedOrders=transactions.slice(0,5);
-	res.status(200).json({transactions:paginatedOrders,hasNext:isMore});
+	const hasPrev=pageNum>1;
+	res.status(200).json({
+		transactions:paginatedOrders,
+		hasNext:isMore,
+		hasPrev:hasPrev
+	});
   } catch (error) {
     console.error(error);
     res.status(500).json({ message: SERVER_ERROR });

--- a/apps/http/src/controllers/userController.ts
+++ b/apps/http/src/controllers/userController.ts
@@ -674,7 +674,7 @@ const getAllOrders = async (
 		return res.status(400).json({ message: "Invalid page number" });
 	}
     const pageNum = parseInt(page , 10);
-    const id = req.user?.canteenId;
+    const id = req.user?.id;
     if (!id) {
       return res.status(400).json({ message: "Invalid user id" });
     }

--- a/apps/http/src/routes/userRoutes.ts
+++ b/apps/http/src/routes/userRoutes.ts
@@ -15,7 +15,7 @@ import {
   verifyOtp,
   updatePhoneNumber,
   deleteAccount,
-  getTransaction,
+  getAllOrders,
 } from "../controllers/userController";
 import { canRequestOtp, isAuthenticatedUser } from "../middlewares/auth";
 
@@ -30,7 +30,7 @@ userRoute.get("/profile", isAuthenticatedUser, getProfile);
 userRoute.post("/updateFcmToken", isAuthenticatedUser, updateFcmToken);
 userRoute.put("/updatePhoneNumber",canRequestOtp, updatePhoneNumber);
 userRoute.get("/logout", isAuthenticatedUser, logout);
-userRoute.get('/getTransaction/:id/:page',isAuthenticatedUser,getTransaction);
+userRoute.get('/getTransaction/:page',isAuthenticatedUser,getAllOrders);
 
 // Password reset flow
 userRoute.put("/password/forgetPassword", forgetPassword);

--- a/apps/http/src/routes/userRoutes.ts
+++ b/apps/http/src/routes/userRoutes.ts
@@ -14,7 +14,8 @@ import {
   resetPassword,
   verifyOtp,
   updatePhoneNumber,
-  deleteAccount
+  deleteAccount,
+  getTransaction,
 } from "../controllers/userController";
 import { canRequestOtp, isAuthenticatedUser } from "../middlewares/auth";
 
@@ -29,6 +30,7 @@ userRoute.get("/profile", isAuthenticatedUser, getProfile);
 userRoute.post("/updateFcmToken", isAuthenticatedUser, updateFcmToken);
 userRoute.put("/updatePhoneNumber",canRequestOtp, updatePhoneNumber);
 userRoute.get("/logout", isAuthenticatedUser, logout);
+userRoute.get('/getTransaction/:id/:page',isAuthenticatedUser,getTransaction);
 
 // Password reset flow
 userRoute.put("/password/forgetPassword", forgetPassword);

--- a/apps/http/src/schemas/userSchemas.ts
+++ b/apps/http/src/schemas/userSchemas.ts
@@ -59,5 +59,7 @@ export const changePasswordSchema = z.object({
   message: "Passwords don't match",
   path: ["confirmPassword"]
 });
-
+export const getAllOrdersSchema = z.object({
+  page:z.string()
+});
 export type SMSMessage = Zod.infer<typeof smsMessage>;


### PR DESCRIPTION
**Pull Request Description:**  

### **Title:** Implement Pagination for Orders with `take`, `skip`, and `orderBy`  

### **Description:**  
This PR adds pagination support for fetching orders using `take`, `skip`, and `orderBy`. Orders are now retrieved in descending order based on `createdAt`, ensuring the latest orders appear first.  

### **Changes:**  
- Implemented **pagination logic** with `take: 5` to fetch only 5 records per page.  
- Used `skip: 5 * (page - 1)` to ensure correct offset for paginated results.  
- Sorted orders by `createdAt: "desc"` so that newer orders appear first.  

### **How It Works:**  
- **Page 1:** Fetches the first 5 newest orders (no skipping).  
- **Page 2:** Skips the first 5 orders and fetches the next 5.  
- Ensures smooth pagination while keeping results consistently ordered.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a secure endpoint that lets authenticated users view their order history.
  - Supports paginated results, displaying a limited number of orders per page.
  - New route for retrieving order information based on pagination.
  - Validation for pagination parameter to ensure it is a valid number.
  - Introduced a new schema for validating order retrieval requests.
  - Enhanced response message for successful account deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->